### PR TITLE
URL Cleanup

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Benchmarks are based on [JMH](http://openjdk.java.net/projects/code-tools/jmh/).
+Benchmarks are based on [JMH](https://openjdk.java.net/projects/code-tools/jmh/).
 
 # Running Benchmarks
 

--- a/release-tools/src/main/java/org/springframework/data/release/cli/StaticResources.java
+++ b/release-tools/src/main/java/org/springframework/data/release/cli/StaticResources.java
@@ -27,7 +27,7 @@ import org.springframework.data.release.model.Project;
 @RequiredArgsConstructor
 public class StaticResources {
 
-	private static final String URL_TEMPLATE = "http://docs.spring.io/spring-data/%s/docs/%s";
+	private static final String URL_TEMPLATE = "https://docs.spring.io/spring-data/%s/docs/%s";
 
 	private final String baseUrl;
 

--- a/release-tools/src/test/resources/integration/jira/__files/issueCreated.json
+++ b/release-tools/src/test/resources/integration/jira/__files/issueCreated.json
@@ -1,5 +1,5 @@
 {
     "id": "10000",
     "key": "DATAREDIS-42",
-    "self": "http://www.example.com/jira/rest/api/2/issue/10000"
+    "self": "https://www.example.com/jira/rest/api/2/issue/10000"
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://openjdk.java.net/projects/code-tools/jmh/ with 1 occurrences migrated to:  
  https://openjdk.java.net/projects/code-tools/jmh/ ([https](https://openjdk.java.net/projects/code-tools/jmh/) result 200).
* [ ] http://www.example.com/jira/rest/api/2/issue/10000 with 1 occurrences migrated to:  
  https://www.example.com/jira/rest/api/2/issue/10000 ([https](https://www.example.com/jira/rest/api/2/issue/10000) result 200).
* [ ] http://docs.spring.io/spring-data/%s/docs/%s with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/%s/docs/%s ([https](https://docs.spring.io/spring-data/%s/docs/%s) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8080/capture-benchmarks with 1 occurrences
* http://localhost:8888 with 2 occurrences