### PR TITLE
Enable commit signing if gpg Properties are set.

### DIFF
--- a/release-tools/application-local.template
+++ b/release-tools/application-local.template
@@ -20,9 +20,9 @@ jira.password=
 jira.url=https://jira.spring.io
 
 # GPG
-deployment.gpg.keyname=
-deployment.gpg.password=
-# deployment.gpg.executable=/usr/local/bin/gpg2
+gpg.keyname=
+gpg.password=
+# gpg.executable=/usr/local/bin/gpg2
 
 # A GitHub token with user:email, read:user and read:org scopes.
 # User needs to be part of the Spring team on GitHub as well.

--- a/release-tools/pom.xml
+++ b/release-tools/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>4.2.0.201601211800-r</version>
+			<version>5.5.1.201910021850-r</version>
 		</dependency>
 
 		<dependency>

--- a/release-tools/readme.md
+++ b/release-tools/readme.md
@@ -16,6 +16,10 @@ Add an `application-local.properties` to the project root and add the following 
 - `maven.mavenHome` - Pointing to the location of your Maven installation.
 - `deployment.api-key` - The API key to use for artifact promotion.
 - `deployment.password` - The password of the deployment user (buildmaster).
+- `gpg.keyname` - The GPG key name.
+- `gpg.password` - The password of your GPG key.
+- `gpg.executable` - Path to your GPG executable, typically `/usr/local/MacGPG2/bin/gpg2` or `/usr/local/bin/gpg`.
+
 
 See `application-local.template` for details.
 

--- a/release-tools/src/main/java/org/springframework/data/release/build/MavenBuildSystem.java
+++ b/release-tools/src/main/java/org/springframework/data/release/build/MavenBuildSystem.java
@@ -34,9 +34,9 @@ import org.springframework.data.release.build.Pom.Artifact;
 import org.springframework.data.release.deployment.DefaultDeploymentInformation;
 import org.springframework.data.release.deployment.DeploymentInformation;
 import org.springframework.data.release.deployment.DeploymentProperties;
-import org.springframework.data.release.deployment.DeploymentProperties.Gpg;
 import org.springframework.data.release.io.Workspace;
 import org.springframework.data.release.model.ArtifactVersion;
+import org.springframework.data.release.model.Gpg;
 import org.springframework.data.release.model.ModuleIteration;
 import org.springframework.data.release.model.Phase;
 import org.springframework.data.release.model.Project;
@@ -66,6 +66,7 @@ class MavenBuildSystem implements BuildSystem {
 	Logger logger;
 	MavenRuntime mvn;
 	DeploymentProperties properties;
+	Gpg gpg;
 
 	/*
 	 * (non-Javadoc)
@@ -331,7 +332,7 @@ class MavenBuildSystem implements BuildSystem {
 
 		logger.log(module, "Deploying artifacts to Sonatype OSS Nexus…");
 
-		Gpg gpg = properties.getGpg();
+		Gpg gpg = this.gpg.isGpgAvailable() ? this.gpg : properties.getGpg();
 
 		CommandLine arguments = CommandLine.of(Goal.DEPLOY, //
 				profile("ci,release,central"), //

--- a/release-tools/src/main/java/org/springframework/data/release/deployment/DeploymentProperties.java
+++ b/release-tools/src/main/java/org/springframework/data/release/deployment/DeploymentProperties.java
@@ -20,6 +20,8 @@ import lombok.Data;
 import java.net.URI;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
+import org.springframework.data.release.model.Gpg;
 import org.springframework.data.release.model.Password;
 import org.springframework.data.release.utils.HttpBasicCredentials;
 import org.springframework.stereotype.Component;
@@ -74,6 +76,11 @@ public class DeploymentProperties {
 		return repositoryPrefix.concat(distributionRepository);
 	}
 
+	@DeprecatedConfigurationProperty(reason = "Moved to gpg.", replacement = "gpg")
+	public Gpg getGpg() {
+		return gpg;
+	}
+
 	/**
 	 * Returns the URI of the staging repository.
 	 *
@@ -119,9 +126,4 @@ public class DeploymentProperties {
 		}
 	}
 
-	@Data
-	public static class Gpg {
-		private String keyname, executable;
-		private Password password;
-	}
 }

--- a/release-tools/src/main/java/org/springframework/data/release/git/GitOperations.java
+++ b/release-tools/src/main/java/org/springframework/data/release/git/GitOperations.java
@@ -174,7 +174,6 @@ public class GitOperations {
 	 * Checks out all projects of the given {@link TrainIteration}.
 	 *
 	 * @param iteration must not be {@literal null}.
-	 * @throws Exception
 	 */
 	public void checkout(TrainIteration iteration) {
 
@@ -275,7 +274,6 @@ public class GitOperations {
 	 * already available.
 	 *
 	 * @param project must not be {@literal null}.
-	 * @throws Exception
 	 */
 	public void update(Project project) {
 
@@ -325,7 +323,7 @@ public class GitOperations {
 		Assert.notNull(project, "Project must not be null!");
 
 		IssueTracker tracker = issueTracker.getRequiredPluginFor(project,
-				() -> String.format("No issue tracker found for project %!", project));
+				() -> String.format("No issue tracker found for project %s!", project));
 
 		return doWithGit(project, git -> {
 
@@ -761,7 +759,7 @@ public class GitOperations {
 		}
 	}
 
-	private void reset(Project project, Branch branch) throws Exception {
+	private void reset(Project project, Branch branch) {
 
 		logger.log(project, "git reset --hard origin/%s", branch);
 
@@ -797,11 +795,11 @@ public class GitOperations {
 		});
 	}
 
-	private static interface GitCallback<T> {
+	private interface GitCallback<T> {
 		T doWithGit(Git git) throws Exception;
 	}
 
-	private static interface VoidGitCallback {
+	private interface VoidGitCallback {
 		void doWithGit(Git git) throws Exception;
 	}
 

--- a/release-tools/src/main/java/org/springframework/data/release/model/Gpg.java
+++ b/release-tools/src/main/java/org/springframework/data/release/model/Gpg.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.release.model;
+
+import lombok.Data;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Oliver Gierke
+ * @author Mark Paluch
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "gpg")
+public class Gpg {
+	private String keyname, executable;
+	private Password password;
+
+	public boolean isGpgAvailable() {
+		return this.password != null && StringUtils.hasText(keyname);
+	}
+}

--- a/release-tools/src/main/resources/application.properties
+++ b/release-tools/src/main/resources/application.properties
@@ -5,21 +5,17 @@ io.logs=logs
 maven.local-repository=~/temp/spring-data-shell/repository
 maven.plugins.versions=org.codehaus.mojo:versions-maven-plugin:2.2
 maven.console-logger=true
-
 deployment.server.uri=https://repo.spring.io
 deployment.staging-repository=libs-staging-local
 deployment.distribution-repository=temp-private-local
 deployment.username=buildmaster
 #deployment.password <- local
-
 # GPG setup
-deployment.gpg.executable=/usr/local/bin/gpg2
-# deployment.gpg.keyname
-# deployment.gpg.password
-
+gpg.executable=/usr/local/bin/gpg2
+# gpg.keyname
+# gpg.password
 # JIRA
 jira.api-url=https://jira.spring.io
-
 # GitHub
 github.api-url=https://api.github.com
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(%-20.20logger{19}){cyan}%clr(:){faint} %m%n%wEx


### PR DESCRIPTION
We now sign commits if GPG properties are set. We pulled GPG properties from deployment.gpg to the top level (gpg).
For the deployment, we fall back to deployment.gpg if toplevel GPG properties aren't set.

See #130.