### PR TITLE
Add benchmarks for after-convert callbacks

### DIFF
--- a/benchmark/commons/pom.xml
+++ b/benchmark/commons/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data.benchmark</groupId>
 		<artifactId>spring-data-benchmark-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-benchmark-commons</artifactId>

--- a/benchmark/mongodb/pom.xml
+++ b/benchmark/mongodb/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data.benchmark</groupId>
 		<artifactId>spring-data-benchmark-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-benchmark-mongodb</artifactId>

--- a/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/AfterConvertCallbacksBenchmark.java
+++ b/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/AfterConvertCallbacksBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,16 +28,16 @@ import org.springframework.data.microbenchmark.mongodb.ProjectionsBenchmark.Pers
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
-import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
+import org.springframework.data.mongodb.core.mapping.event.AfterConvertCallback;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
 /**
- * @author Christoph Strobl
+ * @author Roman Puchkovskiy
  */
-public class CallbacksBenchmark extends AbstractMicrobenchmark {
+public class AfterConvertCallbacksBenchmark extends AbstractMicrobenchmark {
 
 	private MongoTemplate templateWithoutContext;
 	private MongoTemplate templateWithEmptyContext;
@@ -99,8 +99,8 @@ public class CallbacksBenchmark extends AbstractMicrobenchmark {
 	static class EntityCallbackConfig {
 
 		@Bean
-		BeforeConvertCallback<Person> convertCallback() {
-			return (it, document) -> {
+		AfterConvertCallback<Person> afterConvertCallback() {
+			return (it, document, collection) -> {
 
 				Person target = new Person();
 				target.id = it.id;

--- a/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/ProjectionsBenchmark.java
+++ b/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/ProjectionsBenchmark.java
@@ -28,8 +28,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 
 /**
@@ -57,7 +57,7 @@ public class ProjectionsBenchmark extends AbstractMicrobenchmark {
 	@Setup
 	public void setUp() {
 
-		client = new MongoClient(new ServerAddress());
+		client = MongoClients.create();
 		template = new MongoTemplate(client, DB_NAME);
 
 		source = new Person();
@@ -84,7 +84,7 @@ public class ProjectionsBenchmark extends AbstractMicrobenchmark {
 	@TearDown
 	public void tearDown() {
 
-		client.dropDatabase(DB_NAME);
+		client.getDatabase(DB_NAME).drop();
 		client.close();
 	}
 

--- a/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/convert/DbRefMappingBenchmark.java
+++ b/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/convert/DbRefMappingBenchmark.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.data.microbenchmark.mongodb.convert;
 
-import static org.springframework.data.mongodb.core.query.Criteria.*;
-import static org.springframework.data.mongodb.core.query.Query.*;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
 
 import lombok.Data;
 
@@ -24,19 +24,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.bson.types.ObjectId;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.microbenchmark.common.AbstractMicrobenchmark;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.mongodb.core.query.Query;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 
 /**
  * @author Christoph Strobl
@@ -55,7 +51,7 @@ public class DbRefMappingBenchmark extends AbstractMicrobenchmark {
 	@Setup
 	public void setUp() throws Exception {
 
-		client = new MongoClient(new ServerAddress());
+		client = MongoClients.create();
 		template = new MongoTemplate(client, DB_NAME);
 
 		List<RefObject> refObjects = new ArrayList<>();
@@ -80,7 +76,7 @@ public class DbRefMappingBenchmark extends AbstractMicrobenchmark {
 	@TearDown
 	public void tearDown() {
 
-		client.dropDatabase(DB_NAME);
+		client.getDatabase(DB_NAME).drop();
 		client.close();
 	}
 

--- a/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/convert/MappingMongoConverterBenchmark.java
+++ b/benchmark/mongodb/src/main/java/org/springframework/data/microbenchmark/mongodb/convert/MappingMongoConverterBenchmark.java
@@ -20,24 +20,15 @@ import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import org.bson.Document;
 import org.bson.types.ObjectId;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.geo.Point;
 import org.springframework.data.microbenchmark.common.AbstractMicrobenchmark;
-import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -45,8 +36,8 @@ import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.Field;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 
 /**
  * @author Christoph Strobl
@@ -68,13 +59,13 @@ public class MappingMongoConverterBenchmark extends AbstractMicrobenchmark {
 	@Setup
 	public void setUp() throws Exception {
 
-		client = new MongoClient(new ServerAddress());
+		client = MongoClients.create();
 
 		this.mappingContext = new MongoMappingContext();
 		this.mappingContext.setInitialEntitySet(Collections.singleton(Customer.class));
 		this.mappingContext.afterPropertiesSet();
 
-		DbRefResolver dbRefResolver = new DefaultDbRefResolver(new SimpleMongoDbFactory(client, DB_NAME));
+		DbRefResolver dbRefResolver = new DefaultDbRefResolver(new SimpleMongoClientDatabaseFactory(client, DB_NAME));
 
 		this.converter = new MappingMongoConverter(dbRefResolver, mappingContext);
 		this.converter.setCustomConversions(new MongoCustomConversions(Collections.emptyList()));
@@ -120,7 +111,7 @@ public class MappingMongoConverterBenchmark extends AbstractMicrobenchmark {
 	@TearDown
 	public void tearDown() {
 
-		client.dropDatabase(DB_NAME);
+		client.getDatabase(DB_NAME).drop();
 		client.close();
 	}
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<modules>
@@ -35,7 +35,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
-				<version>2.2.0.BUILD-SNAPSHOT</version>
+				<version>2.3.0.BUILD-SNAPSHOT</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -56,6 +56,12 @@
 				<groupId>com.github.mp911de.microbenchmark-runner</groupId>
 				<artifactId>microbenchmark-runner-extras</artifactId>
 				<version>0.2.0.RELEASE</version>
+			</dependency>
+
+			<dependency>
+				<groupId>net.minidev</groupId>
+				<artifactId>json-smart</artifactId>
+				<version>2.3</version>
 			</dependency>
 
 		</dependencies>

--- a/benchmark/relational/pom.xml
+++ b/benchmark/relational/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data.benchmark</groupId>
 		<artifactId>spring-data-benchmark-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-benchmark-relational</artifactId>

--- a/benchmark/support/pom.xml
+++ b/benchmark/support/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.data.benchmark</groupId>
 		<artifactId>spring-data-benchmark-parent</artifactId>
-		<version>2.2.0.BUILD-SNAPSHOT</version>
+		<version>2.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-benchmark-support</artifactId>
@@ -22,8 +22,18 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-sync</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.github.mp911de.microbenchmark-runner</groupId>
 			<artifactId>microbenchmark-runner-junit4</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>net.minidev</groupId>
+			<artifactId>json-smart</artifactId>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
- add the benchmark itself
- migrate to spring-boot dependencies of version 2.3.0
- add mvn wrapper for convenience as enforcer rules require a specific version of maven

This commit is still a WORK IN PROGRESS. A couple of problems for now:
- MongoResultsWriter is broken (code is just commented-out to make the project compile)
- spring-data-mongodb version is forced to be a snapshot one, not the one from spring-boot-dependencies BOM (so that it is possible to benchmark the needed version)