### PR TITLE
Fixed the URL for the Spring Data Commons documentation

### DIFF
--- a/playbooks/commons.yml
+++ b/playbooks/commons.yml
@@ -11,7 +11,7 @@ antora:
       root_component_name: 'data-commons'
 site:
   title: Spring Data Commons
-  url: https://docs.spring.io/spring-data-commons/reference
+  url: https://docs.spring.io/spring-data/commons/reference
   robots: allow
 git:
   ensure_git_suffix: false


### PR DESCRIPTION
I fixed an incorrect URL in the **commons.yml** file.